### PR TITLE
Feature/android gradle plugin 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ https://www.jetbrains.com/help/idea/jetgradle-tool-window.html) or from the term
 # Compatibility
 | Version       | Android Gradle plugin version | Gradle version |
 | ------------- | ----------------------------- | -------------- |
+| **develop**   | 3.4                           | 5.1.1+         |
 | **1.1.1**     | 3.3                           | 4.10.1+        |
 | ~~**1.1.0**~~ | ~~3.3~~                       | ~~5+~~         |
 | **1.0.2**     | 3.2                           | 4.6+           |

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
             // Gradle Plugins
             kotlinPlugin       : "org.jetbrains.kotlin:kotlin-gradle-plugin:${projectVersion.kotlin}",
-            androidGradlePlugin: "com.android.tools.build:gradle:3.4.0",
+            androidGradlePlugin: "com.android.tools.build:gradle:3.4.1",
 
             // Dependencies
             kotlinStdlibJdk7   : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${projectVersion.kotlin}",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,9 +1,9 @@
 ext {
     projectVersion = [
             minSdk    : 19,
-            targetSdk : 28,
-            compileSdk: 28,
-            kotlin    : "1.3.31"
+            targetSdk : 29,
+            compileSdk: 29,
+            kotlin    : "1.3.40"
     ]
     projectDependency = [
 
@@ -17,11 +17,11 @@ ext {
 
             // Test dependencies
             junit              : "junit:junit:4.12",
-            truth              : "com.google.truth:truth:0.44",
+            truth              : "com.google.truth:truth:0.45",
             supportTestRunner  : "androidx.test:runner:1.1.1",
             espressoCore       : "androidx.test.espresso:espresso-core:3.1.1",
             androidJUnit       : "androidx.test.ext:junit:1.1.0",
-            commonsCsv         : "org.apache.commons:commons-csv:1.6",
+            commonsCsv         : "org.apache.commons:commons-csv:1.7",
             kotlinTest         : "org.jetbrains.kotlin:kotlin-test:${projectVersion.kotlin}"
     ]
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,23 +3,24 @@ ext {
             minSdk    : 19,
             targetSdk : 28,
             compileSdk: 28,
-            kotlin    : "1.3.30"
+            kotlin    : "1.3.31"
     ]
     projectDependency = [
 
             // Gradle Plugins
             kotlinPlugin       : "org.jetbrains.kotlin:kotlin-gradle-plugin:${projectVersion.kotlin}",
-            androidGradlePlugin: "com.android.tools.build:gradle:3.3.0",
+            androidGradlePlugin: "com.android.tools.build:gradle:3.4.0",
 
             // Dependencies
             kotlinStdlibJdk7   : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${projectVersion.kotlin}",
-            appCompat          : "androidx.appcompat:appcompat:1.0.0",
+            appCompat          : "androidx.appcompat:appcompat:1.0.2",
 
             // Test dependencies
             junit              : "junit:junit:4.12",
             truth              : "com.google.truth:truth:0.44",
-            supportTestRunner  : "androidx.test:runner:1.1.0",
-            espressoCore       : "androidx.test.espresso:espresso-core:3.1.0",
+            supportTestRunner  : "androidx.test:runner:1.1.1",
+            espressoCore       : "androidx.test.espresso:espresso-core:3.1.1",
+            androidJUnit       : "androidx.test.ext:junit:1.1.0",
             commonsCsv         : "org.apache.commons:commons-csv:1.6",
             kotlinTest         : "org.jetbrains.kotlin:kotlin-test:${projectVersion.kotlin}"
     ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 22 16:40:52 CET 2019
+#Thu Apr 25 15:55:50 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
@@ -52,7 +52,7 @@ class IntegrationTest(
         fun parameters(): List<Array<Any>> {
 
             val testFixtures = File("src/test/test-fixtures").listFiles().filter { it.isDirectory }
-            val gradleVersions = arrayOf("5.1.1", "5.2.1")
+            val gradleVersions = arrayOf("5.1.1", "5.2.1", "5.4.1")
 
             return testFixtures.flatMap { file ->
                 gradleVersions.map { gradleVersion ->

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
@@ -52,7 +52,7 @@ class IntegrationTest(
         fun parameters(): List<Array<Any>> {
 
             val testFixtures = File("src/test/test-fixtures").listFiles().filter { it.isDirectory }
-            val gradleVersions = arrayOf("4.10.1", "5.1.1")
+            val gradleVersions = arrayOf("5.1.1", "5.2.1")
 
             return testFixtures.flatMap { file ->
                 gradleVersions.map { gradleVersion ->

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
@@ -51,7 +51,8 @@ class IntegrationTest(
         @JvmStatic
         fun parameters(): List<Array<Any>> {
 
-            val testFixtures = File("src/test/test-fixtures").listFiles().filter { it.isDirectory }
+            val testFixtures = File("src/test/test-fixtures").listFiles()?.filter { it.isDirectory }
+                    ?: error("Could not list test fixture directories")
             val gradleVersions = arrayOf("5.1.1", "5.2.1", "5.4.1")
 
             return testFixtures.flatMap { file ->

--- a/plugin/src/test/test-fixtures/multi-module/app/build.gradle
+++ b/plugin/src/test/test-fixtures/multi-module/app/build.gradle
@@ -33,7 +33,6 @@ android {
 }
 
 dependencies {
-
     implementation project(":library_android")
 
     implementation projectDependency.kotlinStdlibJdk7
@@ -42,4 +41,5 @@ dependencies {
     testImplementation projectDependency.junit
     androidTestImplementation projectDependency.supportTestRunner
     androidTestImplementation projectDependency.espressoCore
+    androidTestImplementation projectDependency.androidJUnit
 }

--- a/plugin/src/test/test-fixtures/multi-module/app/src/androidTest/java/org/neotech/app/multimoduleapplication/TouchLibraryCodeTest.kt
+++ b/plugin/src/test/test-fixtures/multi-module/app/src/androidTest/java/org/neotech/app/multimoduleapplication/TouchLibraryCodeTest.kt
@@ -1,6 +1,6 @@
 package org.neotech.app.multimoduleapplication
 
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/plugin/src/test/test-fixtures/multi-module/library_android/build.gradle
+++ b/plugin/src/test/test-fixtures/multi-module/library_android/build.gradle
@@ -44,4 +44,5 @@ dependencies {
     testImplementation projectDependency.junit
     androidTestImplementation projectDependency.supportTestRunner
     androidTestImplementation projectDependency.espressoCore
+    androidTestImplementation projectDependency.androidJUnit
 }


### PR DESCRIPTION
- Update Gradle to version 5.4.1
- Update Kotlin to version 1.3.40
- Update Android Gradle Plugin to version 3.4.1
- Update AndroidX AppCompat to version 1.0.2
- Update Google Truth to version 0.45
- Update AndroidX Test Runner to version 1.1.1
- Update Espresso Core to version 3.1.1
- Update Apache Commons CSV to version 1.7
- Update target and compile SDK versions to API level 29 (Android Q)
- Use `androidx.test.ext.junit.runners.AndroidJUnit4` instead of `androidx.test.runner.AndroidJUnit4`
- Added Gradle version 5.4.1 to test fixture