### PR TITLE
Update Gradle, Kotlin and Google Truth dependencies

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,7 +3,7 @@ ext {
             minSdk    : 19,
             targetSdk : 29,
             compileSdk: 29,
-            kotlin    : "1.3.40"
+            kotlin    : "1.3.41"
     ]
     projectDependency = [
 
@@ -17,7 +17,7 @@ ext {
 
             // Test dependencies
             junit              : "junit:junit:4.12",
-            truth              : "com.google.truth:truth:0.45",
+            truth              : "com.google.truth:truth:1.0",
             supportTestRunner  : "androidx.test:runner:1.1.1",
             espressoCore       : "androidx.test.espresso:espresso-core:3.1.1",
             androidJUnit       : "androidx.test.ext:junit:1.1.0",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
@@ -53,7 +53,7 @@ class IntegrationTest(
 
             val testFixtures = File("src/test/test-fixtures").listFiles()?.filter { it.isDirectory }
                     ?: error("Could not list test fixture directories")
-            val gradleVersions = arrayOf("5.1.1", "5.2.1", "5.4.1")
+            val gradleVersions = arrayOf("5.1.1", "5.2.1", "5.4.1", "5.5.1")
 
             return testFixtures.flatMap { file ->
                 gradleVersions.map { gradleVersion ->


### PR DESCRIPTION
- Update Gradle to version 5.5.1
- Update Kotlin to version 1.3.41
- Update Google Truth to version 1.0 🎉