### PR TITLE
Update Kotlin, Gradle, Android Gradle Plugin and AndroidX dependencies

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,24 +3,24 @@ ext {
             minSdk    : 19,
             targetSdk : 29,
             compileSdk: 29,
-            kotlin    : "1.3.41"
+            kotlin    : "1.3.60"
     ]
     projectDependency = [
 
             // Gradle Plugins
             kotlinPlugin       : "org.jetbrains.kotlin:kotlin-gradle-plugin:${projectVersion.kotlin}",
-            androidGradlePlugin: "com.android.tools.build:gradle:3.4.1",
+            androidGradlePlugin: "com.android.tools.build:gradle:3.5.2",
 
             // Dependencies
             kotlinStdlibJdk7   : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${projectVersion.kotlin}",
-            appCompat          : "androidx.appcompat:appcompat:1.0.2",
+            appCompat          : "androidx.appcompat:appcompat:1.1.0",
 
             // Test dependencies
             junit              : "junit:junit:4.12",
             truth              : "com.google.truth:truth:1.0",
-            supportTestRunner  : "androidx.test:runner:1.1.1",
-            espressoCore       : "androidx.test.espresso:espresso-core:3.1.1",
-            androidJUnit       : "androidx.test.ext:junit:1.1.0",
+            supportTestRunner  : "androidx.test:runner:1.2.0",
+            espressoCore       : "androidx.test.espresso:espresso-core:3.2.0",
+            androidJUnit       : "androidx.test.ext:junit:1.1.1",
             commonsCsv         : "org.apache.commons:commons-csv:1.7",
             kotlinTest         : "org.jetbrains.kotlin:kotlin-test:${projectVersion.kotlin}"
     ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
@@ -53,7 +53,7 @@ class IntegrationTest(
 
             val testFixtures = File("src/test/test-fixtures").listFiles()?.filter { it.isDirectory }
                     ?: error("Could not list test fixture directories")
-            val gradleVersions = arrayOf("5.1.1", "5.2.1", "5.4.1", "5.5.1")
+            val gradleVersions = arrayOf("5.4.1", "5.5.1", "5.6.4")
 
             return testFixtures.flatMap { file ->
                 gradleVersions.map { gradleVersion ->


### PR DESCRIPTION
- Update Kotlin to version 1.3.60
- Update Android Gradle Plugin to version 3.5.2
- Update AndroidX AppCompat to version 1.1.0
- Update AndroidX Test Runner to version 1.2.0
- Update AndroidX Espresso to version 3.2.0
- Update AndroidX JUnit Extensions to version 1.1.1
- Update Gradle to version 5.6.4

This update makes the minimum supported Gradle version 5.4.1 and maximum supported Gradle version 5.6.4 (same Gradle versions as supported by Android Gradle Plugin version 3.5.2)