### PR TITLE
Release 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ apply plugin: 'org.neotech.plugin.rootcoverage'
 buildscript {
     dependencies {
         // Step 1: add the dependency
-        classpath 'org.neotech.plugin:android-root-coverage-plugin:1.1.2'
+        classpath 'org.neotech.plugin:android-root-coverage-plugin:1.2.0'
     }
 }
 ```
@@ -51,7 +51,7 @@ android {
 The Android-Root-Coverage-Plugin generates a special Gradle task `:rootCodeCoverageReport` that when
 executed generates a Jacoco code coverage report. You can either run this task directly from
 Android Studio using the Gradle Tool Window (see:
-https://www.jetbrains.com/help/idea/jetgradle-tool-window.html) or from the terminal.
+<https://www.jetbrains.com/help/idea/jetgradle-tool-window.html>) or from the terminal.
 
 - **Gradle Tool Window:** You can find the task under: `Tasks > reporting > rootCodeCoverageReport`, double click to  execute it.
 - **Terminal:** Execute the task using `gradlew rootCodeCoverageReport`.
@@ -60,6 +60,7 @@ https://www.jetbrains.com/help/idea/jetgradle-tool-window.html) or from the term
 # Compatibility
 | Version       | Android Gradle plugin version | Gradle version |
 | ------------- | ----------------------------- | -------------- |
+| **1.2.0**     | 3.5                           | 5.4.1-5.6.4    |
 | **1.1.2**     | 3.4                           | 5.1.1+         |
 | **1.1.1**     | 3.3                           | 4.10.1+        |
 | ~~**1.1.0**~~ | ~~3.3~~                       | ~~5+~~         |
@@ -67,11 +68,11 @@ https://www.jetbrains.com/help/idea/jetgradle-tool-window.html) or from the term
 
 *Note: This plugin normally supports exactly the same Gradle versions as the Android Gradle
 plugin, for more information please refer to:* 
-https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
+<https://developer.android.com/studio/releases/gradle-plugin#updating-gradle>
 
 Android Gradle Plugin versions before `3.4.0-alpha05` are affected by a bug that in certain conditions can
 cause Jacoco instrumentation to fail in combination with inline kotlin methods shared across modules. For more information
-see: https://issuetracker.google.com/issues/109771903 and https://issuetracker.google.com/issues/110763361.
+see: <https://issuetracker.google.com/issues/109771903> and <https://issuetracker.google.com/issues/110763361>.
 If your project is affected by this upgrade to an Android Gradle Plugin version of at least `3.4.0-alpha05`.
 
 
@@ -88,13 +89,23 @@ rootCoverage {
     // Overrides the default build variant for specific modules.
     buildVariantOverrides ":moduleA" : "debugFlavourA", ":moduleB": "debugFlavourA"
     
-
     // Class exclude patterns
     excludes = ["**/some.package/**"]
-    // If true the task it self does not execute any tests (debug option)
-    skipTestExecution false
-    // Type of tests to run (import com.android.builder.model.TestVariantBuildOutput.TestType)
-    testTypes = [TestType.UNIT, TestType.ANDROID_TEST]
+
+    // Since 1.2: When false the plugin does not execute any tests, useful when you run the tests manually or remote (Firebase Test Lab)
+    executeTests true
+    
+    // Since 1.2: Same as executeTests except that this only affects the instrumented Android tests
+    executeAndroidTests true
+
+    // Since 1.2: Same as executeTests except that this only affects the unit tests
+    executeUnitTests true
+
+    // Since 1.2: When true include results from instrumented Android tests into the coverage report
+    includeAndroidTestResults true
+
+    // Since 1.2: When true include results from unit tests into the coverage report
+    includeUnitTestResults true
 }
 ```
 
@@ -105,7 +116,6 @@ projects. But if you like to add some actually functionality, this is the wish l
 
 - Support for Java library modules
 - Make use of the JacocoMerge task? To merge the `exec` en `ec` files?
-- Support for configuring the output type: html, xml etc. (Just like Jacoco)
 - Improved integration test setup: without the hackish dynamic versions in the Gradle plugin block?
 
 **How to test your changes/additions?**

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.21.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.27.0"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx1536m
 #PACKAGING=jar
 
 GROUP=org.neotech.plugin
-VERSION=1.1.2
+VERSION=1.2.0
 DESCRIPTION=A Gradle plugin for easy generation of combined code coverage reports for Android projects with multiple modules.
 
 PROJECT_WEBSITE=https://github.com/NeoTech-Software/android-root-coverage-plugin

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,20 +3,20 @@ ext {
             minSdk    : 19,
             targetSdk : 29,
             compileSdk: 29,
-            kotlin    : "1.3.60"
+            kotlin    : "1.3.61"
     ]
     projectDependency = [
 
             // Gradle Plugins
             kotlinPlugin       : "org.jetbrains.kotlin:kotlin-gradle-plugin:${projectVersion.kotlin}",
-            androidGradlePlugin: "com.android.tools.build:gradle:3.5.2",
+            androidGradlePlugin: "com.android.tools.build:gradle:3.5.3",
 
             // Dependencies
             kotlinStdlibJdk7   : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${projectVersion.kotlin}",
             appCompat          : "androidx.appcompat:appcompat:1.1.0",
 
             // Test dependencies
-            junit              : "junit:junit:4.12",
+            junit              : "junit:junit:4.13",
             truth              : "com.google.truth:truth:1.0",
             supportTestRunner  : "androidx.test:runner:1.2.0",
             espressoCore       : "androidx.test.espresso:espresso-core:3.2.0",


### PR DESCRIPTION
Release highlights:

- Official support for Android Gradle Plugin 3.5 and Gradle 5.6.
- New configuration options that replace the now deprecated `skipTestExecution` and `testTypes` options:
   - `executeTests`: When false the plugin does not execute any tests, so you can run them manually or remote (Firebase Test Lab)
   - `executeAndroidTests`: Same as executeTests except that this only affects the instrumented Android tests
   - `executeUnitTests`: Same as executeTests except that this only affects the unit tests
   - `includeAndroidTestResults`: When true include results from instrumented Android tests into the coverage report
   - `includeUnitTestResults `: When true include results from unit tests into the coverage report