### PR TITLE
Release 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ apply plugin: 'org.neotech.plugin.rootcoverage'
 buildscript {
     dependencies {
         // Step 1: add the dependency
-        classpath 'org.neotech.plugin:android-root-coverage-plugin:1.2.1'
+        classpath 'org.neotech.plugin:android-root-coverage-plugin:1.3.0'
     }
 }
 ```
@@ -60,7 +60,8 @@ Android Studio using the Gradle Tool Window (see:
 # Compatibility
 | Version       | Android Gradle plugin version | Gradle version |
 | ------------- | ----------------------------- | -------------- |
-| **1.2.1**     | 3.5                           | 5.4.1-5.6.4    |
+| **1.3.0**     | 3.6                           | 5.6.4+         |
+| **1.2.1**     | 3.5                           | 5.4.1+         |
 | **1.1.2**     | 3.4                           | 5.1.1+         |
 | **1.1.1**     | 3.3                           | 4.10.1+        |
 | ~~**1.1.0**~~ | ~~3.3~~                       | ~~5+~~         |

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx1536m
 #PACKAGING=jar
 
 GROUP=org.neotech.plugin
-VERSION=1.2.1
+VERSION=1.3.0
 DESCRIPTION=A Gradle plugin for easy generation of combined code coverage reports for Android projects with multiple modules.
 
 PROJECT_WEBSITE=https://github.com/NeoTech-Software/android-root-coverage-plugin


### PR DESCRIPTION
This release officially supports Android Gradle Plugin version 3.6.x and therefore raises the minimum Gradle version to 5.6.4. No other changes are included in this release.