### PR TITLE
Improve support for Robolectric

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/nl.neotech.plugin/android-root-coverage-plugin/maven-metadata.xml.svg?label=Gradle%20Plugin%20Portal)](https://plugins.gradle.org/plugin/nl.neotech.plugin.rootcoverage)
 [![Maven Central](https://img.shields.io/maven-central/v/nl.neotech.plugin/android-root-coverage-plugin?label=Maven%20Central)](https://search.maven.org/artifact/nl.neotech.plugin/android-root-coverage-plugin)
-[![Build](https://github.com/NeoTech-Software/Android-Root-Coverage-Plugin/actions/workflows/build.yml/badge.svg)](https://github.com/NeoTech-Software/Android-Root-Coverage-Plugin/actions/workflows/build.yml)
+[![Build](https://github.com/NeoTech-Software/Android-Root-Coverage-Plugin/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/NeoTech-Software/Android-Root-Coverage-Plugin/actions/workflows/build.yml)
 
 # Android-Root-Coverage-Plugin
 **A Gradle plugin for combined code coverage reports for Android projects.**

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,7 +3,7 @@ ext {
             minSdk    : 19,
             targetSdk : 30,
             compileSdk: 30,
-            kotlin    : "1.4.31"
+            kotlin    : "1.4.31",
     ]
     projectDependency = [
 
@@ -22,7 +22,8 @@ ext {
             espressoCore       : "androidx.test.espresso:espresso-core:3.3.0",
             androidJUnit       : "androidx.test.ext:junit:1.1.2",
             commonsCsv         : "org.apache.commons:commons-csv:1.8",
-            kotlinTest         : "org.jetbrains.kotlin:kotlin-test:${projectVersion.kotlin}"
+            kotlinTest         : "org.jetbrains.kotlin:kotlin-test:${projectVersion.kotlin}",
+            robolectric        : "org.robolectric:robolectric:4.5.1",
     ]
 
     // Used by the plugin-version-handler.gradle
@@ -32,6 +33,6 @@ ext {
             "com.github.dcendents.android-maven": "2.1",
             "com.gradle.plugin-publish"         : "0.13.0",
             "org.jetbrains.dokka"               : "1.4.30",
-            "com.vanniktech.maven.publish"      : "0.14.2"
+            "com.vanniktech.maven.publish"      : "0.14.2",
     ]
 }

--- a/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePluginExtension.kt
+++ b/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePluginExtension.kt
@@ -13,6 +13,8 @@ open class RootCoveragePluginExtension {
     var buildVariant: String = "debug"
     var buildVariantOverrides: Map<String, String> = mutableMapOf()
     var excludes: List<String> = mutableListOf()
+    
+    var includeNoLocationClasses: Boolean = false
 
     /**
      * Same as executeTests inverted.

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
@@ -64,6 +64,7 @@ class IntegrationTest(
         report.assertCoverage("org.neotech.library.android", "LibraryAndroidKotlin")
         report.assertCoverage("org.neotech.app", "AppJava")
         report.assertCoverage("org.neotech.app", "AppKotlin")
+        report.assertCoverage("org.neotech.app", "RobolectricTestedActivity")
     }
 
     private fun BuildResult.assertAppCoverageReport() {
@@ -73,6 +74,7 @@ class IntegrationTest(
 
         report.assertCoverage("org.neotech.app", "AppJava")
         report.assertCoverage("org.neotech.app", "AppKotlin")
+        report.assertCoverage("org.neotech.app", "RobolectricTestedActivity")
     }
 
     private fun BuildResult.assertAndroidLibraryCoverageReport() {

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePluginExtensionTest.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePluginExtensionTest.kt
@@ -16,11 +16,12 @@ class RootCoveragePluginExtensionTest {
     }
 
     @Test
-    fun `non default testTypes overrules include(Unit|Android)TestResults`() {
+    fun `non default testTypes overrules include(Unit or Android)TestResults`() {
         // testTypes overrules includeAndroidTestResults & includeUnitTestResults (when testTypes is not default)
         val config = RootCoveragePluginExtension().apply {
             includeAndroidTestResults = true
             includeUnitTestResults = true
+            @Suppress("DEPRECATION")
             testTypes = listOf()
         }
         assertEquals(false, config.includeUnitTestResults())
@@ -28,11 +29,12 @@ class RootCoveragePluginExtensionTest {
     }
 
     @Test
-    fun `default testTypes does not overrule include(Unit|Android)TestResults`() {
+    fun `default testTypes does not overrule include(Unit or Android)TestResults`() {
         // when testTypes is default includeAndroidTestResults & includeUnitTestResults overrule testTypes
         val config = RootCoveragePluginExtension().apply {
             includeAndroidTestResults = false
             includeUnitTestResults = false
+            @Suppress("DEPRECATION")
             testTypes = listOf(TestVariantBuildOutput.TestType.UNIT, TestVariantBuildOutput.TestType.ANDROID_TEST)
         }
         assertEquals(false, config.includeUnitTestResults())
@@ -40,12 +42,13 @@ class RootCoveragePluginExtensionTest {
     }
 
     @Test
-    fun `shouldExecute(Unit|Android)Tests() returns false when include(Unit|Android)TestResults() returns false`() {
+    fun `shouldExecute(Unit or Android)Tests() returns false when include(Unit or Android)TestResults() returns false`() {
         // When test results are not included into the final report (`include*TestResults`), running the tests does not make sense, therefor
         // make sure `skip*TestExecution` returns false when this is the case.
         val config = RootCoveragePluginExtension().apply {
             includeAndroidTestResults = false
             includeUnitTestResults = false
+            @Suppress("DEPRECATION")
             testTypes = listOf(TestVariantBuildOutput.TestType.UNIT, TestVariantBuildOutput.TestType.ANDROID_TEST)
         }
         assertEquals(false, config.includeUnitTestResults())
@@ -56,7 +59,7 @@ class RootCoveragePluginExtensionTest {
     }
 
     @Test
-    fun `executeTests=false overrules execute(Unit|Android)Tests`() {
+    fun `executeTests=false overrules execute(Unit or Android)Tests`() {
         val config = RootCoveragePluginExtension().apply {
             executeTests = false
         }
@@ -77,7 +80,7 @@ class RootCoveragePluginExtensionTest {
     }
 
     @Test
-    fun `executeTests=true does not overrule execute(Unit|AndroidInstrumented)Tests`() {
+    fun `executeTests=true does not overrule execute(Unit or AndroidInstrumented)Tests`() {
         val config = RootCoveragePluginExtension().apply {
             executeTests = true
         }

--- a/plugin/src/test/test-fixtures/multi-module/app/build.gradle
+++ b/plugin/src/test/test-fixtures/multi-module/app/build.gradle
@@ -36,6 +36,12 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+    
     kotlinOptions {
         jvmTarget = "1.8"
     }
@@ -47,7 +53,8 @@ dependencies {
     implementation projectDependency.kotlinStdlibJdk8
     implementation projectDependency.appCompat
 
-    testImplementation projectDependency.junit
+    testImplementation projectDependency.androidJUnit
+    testImplementation projectDependency.robolectric
     androidTestImplementation projectDependency.supportTestRunner
     androidTestImplementation projectDependency.espressoCore
     androidTestImplementation projectDependency.androidJUnit

--- a/plugin/src/test/test-fixtures/multi-module/app/src/main/AndroidManifest.xml
+++ b/plugin/src/test/test-fixtures/multi-module/app/src/main/AndroidManifest.xml
@@ -1,2 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.neotech.app" />
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.neotech.app"
+    >
+
+    <application>
+        <activity
+            android:name=".RobolectricTestedActivity"
+            android:theme="@style/Theme.AppCompat"
+            />
+    </application>
+
+</manifest>

--- a/plugin/src/test/test-fixtures/multi-module/app/src/main/java/org/neotech/app/RobolectricTestedActivity.java
+++ b/plugin/src/test/test-fixtures/multi-module/app/src/main/java/org/neotech/app/RobolectricTestedActivity.java
@@ -1,0 +1,43 @@
+package org.neotech.app;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.util.Locale;
+
+/**
+ * Super simple activity that is unit-tested (non-instrumented) using Robolectric.
+ */
+public class RobolectricTestedActivity extends AppCompatActivity implements View.OnClickListener {
+
+    private TextView textViewCount;
+    private int count = 0;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_robolectric_tested);
+
+        findViewById(R.id.button_increment_count).setOnClickListener(this);
+        findViewById(R.id.button_decrement_count).setOnClickListener(this);
+        textViewCount = findViewById(R.id.text_count);
+        setCount(0);
+    }
+
+    @Override
+    public void onClick(View v) {
+        if (v.getId() == R.id.button_increment_count) {
+            setCount(++count);
+        } else {
+            setCount(--count);
+        }
+    }
+
+    public void setCount(int count) {
+        textViewCount.setText(String.format(Locale.getDefault(), "Count: %d", count));
+    }
+}

--- a/plugin/src/test/test-fixtures/multi-module/app/src/main/res/layout/activity_robolectric_tested.xml
+++ b/plugin/src/test/test-fixtures/multi-module/app/src/main/res/layout/activity_robolectric_tested.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    >
+
+    <TextView
+        android:id="@+id/text_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="Count: 4"
+        />
+
+    <Button
+        android:id="@+id/button_increment_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Increment"
+        tools:ignore="HardcodedText"
+        />
+
+    <Button
+        android:id="@+id/button_decrement_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Decrement"
+        tools:ignore="HardcodedText"
+        />
+
+</LinearLayout>

--- a/plugin/src/test/test-fixtures/multi-module/app/src/test/java/org/neotech/app/RobolectricUnitTest.java
+++ b/plugin/src/test/test-fixtures/multi-module/app/src/test/java/org/neotech/app/RobolectricUnitTest.java
@@ -1,0 +1,42 @@
+package org.neotech.app;
+
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.test.core.app.ActivityScenario;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Super simple Robolectric activity test that is solely used to verify whether coverage is
+ * correctly reported when enabling jacoco.includeNoLocationClasses.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class RobolectricUnitTest {
+
+    @Test
+    public void counter_is_incremented_after_increment_button_click() {
+        ActivityScenario.launch(RobolectricTestedActivity.class).onActivity(activity -> {
+            Button button = activity.findViewById(R.id.button_increment_count);
+            button.performClick();
+            
+            TextView textView = activity.findViewById(R.id.text_count);
+            assertEquals("Count: 1", textView.getText());
+        });
+    }
+    
+    @Test
+    public void counter_is_decrement_after_decrement_button_click() {
+        ActivityScenario.launch(RobolectricTestedActivity.class).onActivity(activity -> {
+            Button button = activity.findViewById(R.id.button_decrement_count);
+            button.performClick();
+            
+            TextView textView = activity.findViewById(R.id.text_count);
+            assertEquals("Count: -1", textView.getText());
+        });
+    }
+}

--- a/plugin/src/test/test-fixtures/multi-module/build.gradle
+++ b/plugin/src/test/test-fixtures/multi-module/build.gradle
@@ -50,4 +50,5 @@ rootCoverage {
     executeTests true
     includeUnitTestResults true
     includeAndroidTestResults true
+    includeNoLocationClasses true
 }


### PR DESCRIPTION
This adds an option `includeNoLocationClasses` to the rootCoverage extension to set Jacoco's `includeNoLocationClasses`. Which makes it easier to support the Jacoco + Robolectric use-case.