### PR TITLE
Release 1.4.0

### DIFF
--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,4 +1,4 @@
 POM_ARTIFACT_ID=android-root-coverage-plugin
-VERSION_NAME=1.3.1
+VERSION_NAME=1.4.0
 POM_NAME=Android Root Coverage Plugin
 POM_DESCRIPTION=A Gradle plugin for easy generation of combined code coverage reports for Android projects with multiple modules.


### PR DESCRIPTION
Release highlights:

- Support for Android Gradle Plugin 4.1 _(although version 1.3.0 also works fine with AGP 4.1)_;
- Support for per module code coverage. Generate a module specific report by running `./gradlew yourModule:codeCoverage`;
- New configuration option `includeNoLocationClasses` which (like the name implies) sets Jacoco's `includeNoLocationClasses`. This makes using the plugin in combination with Robolectric easier, since Robolectric often requires `includeNoLocationClasses` to be set to `true`;
- The "Jacoco has been automatically applied" message is not longer a warning but now an info message.