### PR TITLE
Support for Android Gradle Plugin version 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          # Robolectric requires Java 9 to emulate Android API level 30
-          java-version: '9'
+          # Robolectric requires Java 11 to compile at Android API level 31
+          java-version: '11'
       - name: test
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,38 +1,38 @@
 ext {
     projectVersion = [
             minSdk    : 19,
-            targetSdk : 30,
-            compileSdk: 30,
-            kotlin    : "1.4.31",
+            targetSdk : 31,
+            compileSdk: 31,
+            kotlin    : "1.5.20",
     ]
     projectDependency = [
 
             // Gradle Plugins
             kotlinPlugin       : "org.jetbrains.kotlin:kotlin-gradle-plugin:${projectVersion.kotlin}",
-            androidGradlePlugin: "com.android.tools.build:gradle:4.1.2",
+            androidGradlePlugin: "com.android.tools.build:gradle:7.2.0-alpha06",
 
             // Dependencies
             kotlinStdlibJdk8   : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${projectVersion.kotlin}",
-            appCompat          : "androidx.appcompat:appcompat:1.2.0",
+            kotlinReflect      : "org.jetbrains.kotlin:kotlin-reflect:${projectVersion.kotlin}",
+            appCompat          : "androidx.appcompat:appcompat:1.4.0",
 
             // Test dependencies
             junit              : "junit:junit:4.13.2",
-            truth              : "com.google.truth:truth:1.1.2",
-            supportTestRunner  : "androidx.test:runner:1.2.0",
-            espressoCore       : "androidx.test.espresso:espresso-core:3.3.0",
-            androidJUnit       : "androidx.test.ext:junit:1.1.2",
+            truth              : "com.google.truth:truth:1.1.3",
+            supportTestRunner  : "androidx.test:runner:1.4.0",
+            espressoCore       : "androidx.test.espresso:espresso-core:3.4.0",
+            androidJUnit       : "androidx.test.ext:junit:1.1.3",
             commonsCsv         : "org.apache.commons:commons-csv:1.8",
             kotlinTest         : "org.jetbrains.kotlin:kotlin-test:${projectVersion.kotlin}",
-            robolectric        : "org.robolectric:robolectric:4.5.1",
+            robolectric        : "org.robolectric:robolectric:4.7.3",
     ]
 
     // Used by the plugin-version-handler.gradle
     pluginVersions = [
-            "org.jetbrains.kotlin.android"      : "${projectVersion.kotlin}",
-            "org.jetbrains.kotlin.jvm"          : "${projectVersion.kotlin}",
-            "com.github.dcendents.android-maven": "2.1",
-            "com.gradle.plugin-publish"         : "0.13.0",
-            "org.jetbrains.dokka"               : "1.4.30",
-            "com.vanniktech.maven.publish"      : "0.14.2",
+            "org.jetbrains.kotlin.android": "${projectVersion.kotlin}",
+            "org.jetbrains.kotlin.jvm"    : "${projectVersion.kotlin}",
+            "com.gradle.plugin-publish"   : "0.15.0",
+            "org.jetbrains.dokka"         : "1.5.0",
+            "com.vanniktech.maven.publish": "0.14.2",
     ]
 }

--- a/gradle/plugin-version-handler.gradle
+++ b/gradle/plugin-version-handler.gradle
@@ -34,6 +34,7 @@ apply from: "dependencies.gradle"
 
 resolutionStrategy {
     eachPlugin {
+        // pluginVersions must be added in dependencies.gradle as extension to this project.
         def version = pluginVersions[requested.id.id]
         if (requested.version == null && version != null) {
             useVersion version

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
     // For publishing to Plugin Portal & Maven Central
     id "com.gradle.plugin-publish"
-    id "com.github.dcendents.android-maven"
     id "org.jetbrains.dokka"
     id "com.vanniktech.maven.publish" apply false
 }
@@ -89,6 +88,7 @@ dependencies {
     compileOnly gradleApi()
     implementation projectDependency.androidGradlePlugin
     implementation projectDependency.kotlinStdlibJdk8
+    implementation projectDependency.kotlinReflect
 
     testImplementation projectDependency.kotlinStdlibJdk8
     testImplementation projectDependency.kotlinTest

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,4 +1,4 @@
 POM_ARTIFACT_ID=android-root-coverage-plugin
-VERSION_NAME=1.4.0
+VERSION_NAME=1.5.0-SNAPSHOT
 POM_NAME=Android Root Coverage Plugin
 POM_DESCRIPTION=A Gradle plugin for easy generation of combined code coverage reports for Android projects with multiple modules.

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/CsvCoverageReport.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/CsvCoverageReport.kt
@@ -1,11 +1,11 @@
 package org.neotech.plugin.rootcoverage
 
-import junit.framework.Assert.assertEquals
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVParser
 import org.apache.commons.csv.CSVRecord
 import java.io.File
 import java.nio.charset.StandardCharsets
+import kotlin.test.assertEquals
 
 class CoverageReport private constructor(
         private val instructionMissedColumn: Int,

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
@@ -107,7 +107,7 @@ class IntegrationTest(
 
             val testFixtures = File("src/test/test-fixtures").listFiles()?.filter { it.isDirectory }
                 ?: error("Could not list test fixture directories")
-            val gradleVersions = arrayOf("6.5.1", "6.6.1", "6.7.1", "6.8.3")
+            val gradleVersions = arrayOf("7.3.3")
             return testFixtures.flatMap { file ->
                 gradleVersions.map { gradleVersion ->
                     arrayOf("${file.name}-$gradleVersion", file, gradleVersion)

--- a/plugin/src/test/test-fixtures/multi-module/app/build.gradle
+++ b/plugin/src/test/test-fixtures/multi-module/app/build.gradle
@@ -35,7 +35,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    
+
     testOptions {
         unitTests {
             includeAndroidResources = true

--- a/plugin/src/test/test-fixtures/multi-module/library_android/build.gradle
+++ b/plugin/src/test/test-fixtures/multi-module/library_android/build.gradle
@@ -21,11 +21,6 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
     buildTypes {
         debug {
             testCoverageEnabled true
@@ -37,8 +32,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {


### PR DESCRIPTION
In Android Gradle Plugin 7.0 a bug was introduced causing instrumented coverage for Android library projects to fail: https://issuetracker.google.com/issues/195860510

This bug has finally been fixed in an alpha release of AGP 7.2 (`7.2.0-alpha06`). Unfortunately no hot-fix has been released for 7.0 or the 7.1 (which is in beta), only the canary version (7.2) received this fix for now.

As long as there are no hot-fixes for AGP 7.0 and 7.1 specifically I will work towards a release that works at least with AGP 7.2.

This PR contains the necessary changes to work with AGP version 7.2.0-alpha06 and also includes the following other changes:

- Increased the target and compile SDK version to API level 31 for the test fixtures. This also requires the build to use Java 11.
- Upgraded several test related dependencies (AppCompat,  Google Truth, Robolectric etc.).
- Upgraded to Kotlin 1.5

Fixes: #36 