### PR TITLE
Update: Android Gradle Plugin dependency to stable 7.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ androidMinSdk       = "19"
 androidTargetSdk    = "31"
 androidCompileSdk   = "31"
 kotlin              = "1.5.31"
-androidGradlePlugin = "7.2.0-rc01"
+androidGradlePlugin = "7.2.0"
 
 [libraries]
 appCompat              = { module = "androidx.appcompat:appcompat",            version = "1.4.0" }

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
@@ -108,7 +108,7 @@ class IntegrationTest(
 
             val testFixtures = File("src/test/test-fixtures").listFiles()?.filter { it.isDirectory }
                 ?: error("Could not list test fixture directories")
-            val gradleVersions = arrayOf("7.3.3", "7.4", "7.4.2")
+            val gradleVersions = arrayOf("7.3.3", "7.4", "7.4.2", "7.5-rc-1")
             return testFixtures.flatMap { file ->
                 gradleVersions.map { gradleVersion ->
                     arrayOf("${file.name}-$gradleVersion", file, gradleVersion)


### PR DESCRIPTION
Updated the Android Gradle Plugin dependency to stable 7.2.0, also updated the integration test to also run on the latest Gradle release candidate (7.5-rc-1).