### PR TITLE
Remove: some unnecessary code

### DIFF
--- a/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePlugin.kt
+++ b/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePlugin.kt
@@ -153,10 +153,6 @@ class RootCoveragePlugin : Plugin<Project> {
         androidComponents.onVariants { variant ->
             val buildType = buildTypes.find { it.name == variant.buildType }!!
             if (buildType.isTestCoverageEnabled && variant.name.replaceFirstChar(Char::titlecase) == buildVariant.replaceFirstChar(Char::titlecase)) {
-                if (subProject.plugins.withType(JacocoPlugin::class.java).isEmpty()) {
-                    subProject.plugins.apply(JacocoPlugin::class.java)
-                    subProject.logJacocoHasBeenApplied()
-                }
                 addSubProjectVariant(subProject, variant)
             }
         }
@@ -219,12 +215,6 @@ class RootCoveragePlugin : Plugin<Project> {
                 }
             }
         }
-    }
-
-    private fun Project.logJacocoHasBeenApplied() {
-        project.logger.info(
-            "Note: Jacoco plugin was not found for project '${project.name}', it has been applied automatically: ${project.buildFile}"
-        )
     }
 }
 


### PR DESCRIPTION
- Applying the the `JacocoPlugin` within `addSubProjectInternal()` is duplicate code, since this check is already done in `addSubProject()`.
- `logJacocoHasBeenApplied()` is also no longer needed, since this plugin should no longer warn users about JaCoCo being applied.