### PR TITLE
Fix: BuildConfig file not generated/disappearing

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -67,7 +67,7 @@ test {
 
 dependencies {
     compileOnly gradleApi()
-    implementation libs.androidGradlePluginApi
+    implementation libs.androidGradlePlugin
 
     // Without depending on the full Android Gradle Plugin, the test fixture is unable to locate the Android Gradle Plugin.
     // Not sure why this is, but for now this is a quick fx to add it to the TestKit classpath.

--- a/plugin/src/test/test-fixtures/multi-module/app/build.gradle
+++ b/plugin/src/test/test-fixtures/multi-module/app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    alias(libs.plugins.androidApp)
+    id "com.android.application"
     alias(libs.plugins.kotlinAndroid)
 }
 

--- a/plugin/src/test/test-fixtures/multi-module/app/src/main/java/org/neotech/app/AppJava.java
+++ b/plugin/src/test/test-fixtures/multi-module/app/src/main/java/org/neotech/app/AppJava.java
@@ -12,7 +12,9 @@ public final class AppJava {
     }
 
     private AppJava() {
-
+        // Check if the BuildConfig file is available, this is here to prevent regression on:
+        // https://github.com/NeoTech-Software/Android-Root-Coverage-Plugin/issues/54
+        System.out.println(org.neotech.app.BuildConfig.DEBUG);
     }
 
     public String touchedByJavaInstrumentedTestInApp() {

--- a/plugin/src/test/test-fixtures/multi-module/library_android/build.gradle
+++ b/plugin/src/test/test-fixtures/multi-module/library_android/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
+    id "com.android.library"
     alias(libs.plugins.kotlinAndroid)
 }
 

--- a/plugin/src/test/test-fixtures/multi-module/library_android/src/main/java/org/neotech/library/android/LibraryAndroidJava.java
+++ b/plugin/src/test/test-fixtures/multi-module/library_android/src/main/java/org/neotech/library/android/LibraryAndroidJava.java
@@ -12,7 +12,9 @@ public final class LibraryAndroidJava {
     }
 
     private LibraryAndroidJava() {
-
+        // Check if the BuildConfig file is available, this is here to prevent regression on:
+        // https://github.com/NeoTech-Software/Android-Root-Coverage-Plugin/issues/54
+        System.out.println(org.neotech.library.a.BuildConfig.DEBUG);
     }
 
     public String touchedByJavaInstrumentedTestInAndroidLibrary() {


### PR DESCRIPTION
Apparently using `variant.sources.java.all` in AGP 7.2 causes `BuildConfig` files to disappear or not generate at all, this is very likely a bug in AGP 7.2 because it is working in AGP 7.3.0-beta01. For now this is a workaround that reintroduces code that utilizes old non-public AGP code, but at least this code is working.

Fixes #54