### PR TITLE
Release 1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ following methods:
   ```groovy
   // Below buildscript {}
   plugins {
-      id "nl.neotech.plugin.rootcoverage" version "1.5.0"
+      id "nl.neotech.plugin.rootcoverage" version "1.5.1"
   }
   ```
 </details>
@@ -41,7 +41,7 @@ following methods:
    
    buildscript {
       dependencies {
-         classpath 'nl.neotech.plugin:android-root-coverage-plugin:1.5.0'
+         classpath 'nl.neotech.plugin:android-root-coverage-plugin:1.5.1'
       }
    }
    ```
@@ -121,16 +121,16 @@ rootCoverage {
 
 
 # 4. Compatibility
-| Version            | [Android Gradle plugin version](https://developer.android.com/studio/releases/gradle-plugin#updating-gradle) | Gradle version    |
-| ------------------ | ------------------------------------------------------------------------------------------------------------ | ----------------- |
-| **1.5.0**          | 7.2                                                                                                  | 7.3+              |
-| **See note 2**     | 7.0-7.2-alpha05                                                                                              | n.a.              |
-| **1.4.0**          | 4.2<br/>4.1                                                                                                  | 6.7.1+<br/>6.5+   |
-| **1.3.1**          | 4.0<br/>3.6                                                                                                  | 6.1.1+<br/>5.6.4+ |
-| **1.2.1**          | 3.5                                                                                                          | 5.4.1+            |
-| **1.1.2**          | 3.4                                                                                                          | 5.1.1+            |
-| **1.1.1**          | 3.3                                                                                                          | 4.10.1+           |
-| **1.0.2**          | 3.2                                                                                                          | 4.6+              |
+| Version        | [Android Gradle plugin version](https://developer.android.com/studio/releases/gradle-plugin#updating-gradle) | Gradle version    |
+|----------------|--------------------------------------------------------------------------------------------------------------|-------------------|
+| **1.5.1**      | 7.2                                                                                                          | 7.3+              |
+| **See note 2** | 7.0-7.2-alpha05                                                                                              | n.a.              |
+| **1.4.0**      | 4.2<br/>4.1                                                                                                  | 6.7.1+<br/>6.5+   |
+| **1.3.1**      | 4.0<br/>3.6                                                                                                  | 6.1.1+<br/>5.6.4+ |
+| **1.2.1**      | 3.5                                                                                                          | 5.4.1+            |
+| **1.1.2**      | 3.4                                                                                                          | 5.1.1+            |
+| **1.1.1**      | 3.3                                                                                                          | 4.10.1+           |
+| **1.0.2**      | 3.2                                                                                                          | 4.6+              |
 
 > *Note 1: Plugin versions below 1.3.1, such as 1.3.0, are only available on the Gradle Plugin Portal
 (`maven { url "https://plugins.gradle.org/m2/"}`) and not on Maven Central. These versions use the

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,4 +1,4 @@
 POM_ARTIFACT_ID=android-root-coverage-plugin
-VERSION_NAME=1.5.0
+VERSION_NAME=1.5.1
 POM_NAME=Android Root Coverage Plugin
 POM_DESCRIPTION=A Gradle plugin for easy generation of combined code coverage reports for Android projects with multiple modules.


### PR DESCRIPTION
Fixes #54 but reintroduces the dependency on the full Android Gradle Plugin instead of just depending on the Android Gradle Plugin API. This should be temporary as this workaround does not seem to be needed in AGP 7.3.0.