### PR TITLE
Release 1.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ following methods:
   ```groovy
   // Below buildscript {}
   plugins {
-      id "nl.neotech.plugin.rootcoverage" version "1.5.1"
+      id "nl.neotech.plugin.rootcoverage" version "1.5.2"
   }
   ```
 </details>
@@ -42,7 +42,7 @@ following methods:
    
    buildscript {
       dependencies {
-         classpath 'nl.neotech.plugin:android-root-coverage-plugin:1.5.1'
+         classpath 'nl.neotech.plugin:android-root-coverage-plugin:1.5.2'
       }
    }
    ```
@@ -124,7 +124,7 @@ rootCoverage {
 # 4. Compatibility
 | Version        | [Android Gradle plugin version](https://developer.android.com/studio/releases/gradle-plugin#updating-gradle) | Gradle version    |
 |----------------|--------------------------------------------------------------------------------------------------------------|-------------------|
-| **1.5.1**      | 7.2                                                                                                          | 7.3+              |
+| **1.5.2**      | 7.2                                                                                                          | 7.3+              |
 | **See note 2** | 7.0-7.2-alpha05                                                                                              | n.a.              |
 | **1.4.0**      | 4.2<br/>4.1                                                                                                  | 6.7.1+<br/>6.5+   |
 | **1.3.1**      | 4.0<br/>3.6                                                                                                  | 6.1.1+<br/>5.6.4+ |

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,4 +1,4 @@
 POM_ARTIFACT_ID=android-root-coverage-plugin
-VERSION_NAME=1.5.1
+VERSION_NAME=1.5.2
 POM_NAME=Android Root Coverage Plugin
 POM_DESCRIPTION=A Gradle plugin for easy generation of combined code coverage reports for Android projects with multiple modules.


### PR DESCRIPTION
Fixes #60 (source files not added to report), which was introduced in release 1.5.1 (#54). While technically speaking not breaking coverage, it makes the HTML reports less useful. Test cases have been added to avoid this in the future.