### PR TITLE
Fix: Crash during configuration on Windows

### DIFF
--- a/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePlugin.kt
+++ b/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePlugin.kt
@@ -165,7 +165,7 @@ class RootCoveragePlugin : Plugin<Project> {
         val name = variant.name.replaceFirstChar(Char::titlecase)
 
         // Gets the relative path from this task to the subProject
-        val path = project.relativePath(subProject.path).removeSuffix(":")
+        val path = project.relativeProjectPath(subProject.path)
 
         // Add dependencies to the test tasks of the subProject
         if (rootProjectExtension.shouldExecuteUnitTests()) {


### PR DESCRIPTION
Changed `Project.getRelativePath()` to `Project.getRelativeProjectPath()`, since what was needed is the logical Gradle (project) relative path, not the file-system relative path.

Fixes #64