### PR TITLE
Update: support for Android Gradle Plugin 7.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
 androidMinSdk       = "19"
-androidTargetSdk    = "31"
-androidCompileSdk   = "31"
-kotlin              = "1.5.31"
-androidGradlePlugin = "7.2.0"
+androidTargetSdk    = "32"
+androidCompileSdk   = "32"
+kotlin              = "1.6.21"
+androidGradlePlugin = "7.3.0"
 
 [libraries]
-appCompat              = { module = "androidx.appcompat:appcompat",            version = "1.4.0" }
-androidGradlePlugin    = { module = "com.android.tools.build:gradle",      version.ref = "androidGradlePlugin" }
-androidGradlePluginApi = { module = "com.android.tools.build:gradle-api",      version.ref = "androidGradlePlugin" }
+appCompat              = { module = "androidx.appcompat:appcompat",         version = "1.5.0" }
+androidGradlePlugin    = { module = "com.android.tools.build:gradle",       version.ref = "androidGradlePlugin" }
+androidGradlePluginApi = { module = "com.android.tools.build:gradle-api",   version.ref = "androidGradlePlugin" }
 
 # Test dependencies
 junit               = { module = "junit:junit",                             version = "4.13.2" }
@@ -18,8 +18,8 @@ espressoCore        = { module = "androidx.test.espresso:espresso-core",    vers
 androidJUnit        = { module = "androidx.test.ext:junit",                 version = "1.1.3" }
 commonsCsv          = { module = "org.apache.commons:commons-csv",          version = "1.9.0" }
 kotlinTest          = { module = "org.jetbrains.kotlin:kotlin-test",        version.ref = "kotlin" }
-robolectric         = { module = "org.robolectric:robolectric",             version = "4.7.3" }
-mockk               = { module = "io.mockk:mockk",                          version = "1.12.4" }
+robolectric         = { module = "org.robolectric:robolectric",             version = "4.8.2" }
+mockk               = { module = "io.mockk:mockk",                          version = "1.12.5" }
 
 [bundles]
 androidInstrumentedTest = ["supportTestRunner", "espressoCore", "androidJUnit"]
@@ -31,7 +31,7 @@ kotlinJvm           = { id = "org.jetbrains.kotlin.jvm",        version.ref = "k
 kotlinAndroid       = { id = "org.jetbrains.kotlin.android",    version.ref = "kotlin" }
 kotlinDokka         = { id = "org.jetbrains.dokka",             version.ref = "kotlin" }
 pluginPortalPublish = { id = "com.gradle.plugin-publish",       version = "0.21.0" }
-mavenPublish        = { id = "com.vanniktech.maven.publish",    version = "0.19.0" }
+mavenPublish        = { id = "com.vanniktech.maven.publish",    version = "0.21.0" }
 versionCheck        = { id = "com.github.ben-manes.versions",   version = "0.42.0" }
 androidApp          = { id = "com.android.application",         version.ref = "androidGradlePlugin"}
 androidLibrary      = { id = "com.android.library",             version.ref = "androidGradlePlugin"}

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -32,8 +32,9 @@ jacocoTestReport {
 }
 
 plugins.withId("com.vanniktech.maven.publish") {
-    mavenPublish {
-        sonatypeHost = "S01"
+    mavenPublishing {
+        publishToMavenCentral("S01")
+        signAllPublications()
     }
 }
 

--- a/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/JaCoCoConfiguration.kt
+++ b/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/JaCoCoConfiguration.kt
@@ -35,7 +35,7 @@ internal fun RootCoveragePluginExtension.getFileFilterPatterns(): List<String> =
 internal fun RootCoveragePluginExtension.getBuildVariantFor(project: Project): String =
     buildVariantOverrides[project.path] ?: buildVariant
 
-internal fun RootCoveragePluginExtension.getExecutionDataFileTree(project: Project): FileTree {
+internal fun Project.getExecutionDataFileTree(includeUnitTestResults: Boolean, includeAndroidTestResults: Boolean): FileTree? {
     val buildFolderPatterns = mutableListOf<String>()
     if (includeUnitTestResults) {
         // TODO instead of hardcoding this, obtain the location from the test tasks, something like this:
@@ -68,5 +68,9 @@ internal fun RootCoveragePluginExtension.getExecutionDataFileTree(project: Proje
         // Android Build Tools Plugin 7.1+
         buildFolderPatterns.add("outputs/code_coverage/*/connected/*/coverage.ec")
     }
-    return project.fileTree(project.buildDir, includes = buildFolderPatterns)
+    return if(buildFolderPatterns.isEmpty()) {
+        null
+    } else {
+        fileTree(buildDir, includes = buildFolderPatterns)
+    }
 }

--- a/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePlugin.kt
+++ b/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePlugin.kt
@@ -175,30 +175,7 @@ class RootCoveragePlugin : Plugin<Project> {
             dependsOn("$path:connected${name}AndroidTest")
         }
 
-
-        // Start temporary fix for AGP 7.2
-        // For some reason `variant.sources.java.all` causes BuildConfig files to go missing
-        // See: https://github.com/NeoTech-Software/Android-Root-Coverage-Plugin/issues/54
-        val baseVariant = when(val androidExtension = subProject.extensions.findByName("android")) {
-            is LibraryExtension -> androidExtension.libraryVariants
-            is AppExtension -> androidExtension.applicationVariants
-            else -> {
-                subProject.logger.warn(
-                    "Note: Skipping code coverage for module '${subProject.name}', currently the" +
-                            " RootCoveragePlugin only supports Android Library and App Modules.")
-                    return
-            }
-        }
-        baseVariant.all {
-            if(name.contentEquals(it.baseName, ignoreCase = true)) {
-                val sourceFiles = it.getSourceFolders(SourceKind.JAVA).map { file -> file.dir }
-                sourceDirectories.from(subProject.files(sourceFiles))
-            }
-        }
-        // End temporary fix for AGP 7.2
-
-        // Working code in AGP 7.3-beta01:
-        // sourceDirectories.from(variant.sources.java?.all)
+        sourceDirectories.from(variant.sources.java?.all)
 
         classDirectories.from(variant.artifacts.getAll(MultipleArtifact.ALL_CLASSES_DIRS).map {
             it.map { directory ->

--- a/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/utilities/AndroidGradlePluginExtensions.kt
+++ b/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/utilities/AndroidGradlePluginExtensions.kt
@@ -28,8 +28,6 @@ fun Project.onVariant(variantName: String, action: (variant: Variant?) -> Unit){
     }
 }
 
-
-
 fun Project.afterAndroidPluginApplied(notFoundAction: () -> Unit = {}, action: (AppliedPlugin) -> Unit) {
     var didExecuteBlock = false
     pluginManager.withPlugin(ANDROID_APPLICATION_PLUGIN_ID) {

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
@@ -13,7 +13,6 @@ import org.neotech.plugin.rootcoverage.util.createLocalPropertiesFile
 import org.neotech.plugin.rootcoverage.util.put
 import java.io.File
 import java.util.Properties
-import kotlin.test.assertEquals
 
 @RunWith(Parameterized::class)
 class IntegrationTest(
@@ -60,10 +59,10 @@ class IntegrationTest(
     }
 
     private fun BuildResult.assertRootCoverageReport(file: File) {
-        assertEquals(task(":rootCoverageReport")!!.outcome, TaskOutcome.SUCCESS)
+        assertThat(task(":rootCoverageReport")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
         // Also check if the old task name is still exe
-        assertEquals(task(":rootCodeCoverageReport")!!.outcome, TaskOutcome.SUCCESS)
+        assertThat(task(":rootCodeCoverageReport")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
         val report = CoverageReport.from(file)
 
@@ -75,7 +74,7 @@ class IntegrationTest(
     }
 
     private fun BuildResult.assertAppCoverageReport() {
-        assertEquals(task(":app:coverageReport")!!.outcome, TaskOutcome.SUCCESS)
+        assertThat(task(":app:coverageReport")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
         val report = CoverageReport.from(File(projectRoot, "app/build/reports/jacoco.csv"))
 
@@ -86,7 +85,7 @@ class IntegrationTest(
     }
 
     private fun BuildResult.assertAndroidLibraryCoverageReport() {
-        assertEquals(task(":library_android:coverageReport")!!.outcome, TaskOutcome.SUCCESS)
+        assertThat(task(":library_android:coverageReport")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
         val report = CoverageReport.from(File(projectRoot, "library_android/build/reports/jacoco.csv"))
 

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
@@ -127,7 +127,7 @@ class IntegrationTest(
 
             val testFixtures = File("src/test/test-fixtures").listFiles()?.filter { it.isDirectory }
                 ?: error("Could not list test fixture directories")
-            val gradleVersions = arrayOf("7.3.3", "7.4", "7.4.2", "7.5-rc-1")
+            val gradleVersions = arrayOf("7.4", "7.4.2", "7.5.1")
             return testFixtures.flatMap { file ->
                 gradleVersions.map { gradleVersion ->
                     arrayOf("${file.name}-$gradleVersion", file, gradleVersion)

--- a/plugin/src/test/test-fixtures/multi-module/app/build.gradle
+++ b/plugin/src/test/test-fixtures/multi-module/app/build.gradle
@@ -5,7 +5,9 @@ plugins {
 
 android {
 
+    namespace "org.neotech.app"
     compileSdkVersion libs.versions.androidCompileSdk.get().toInteger()
+
     defaultConfig {
         applicationId "org.neotech.app"
         minSdkVersion libs.versions.androidMinSdk.get().toInteger()
@@ -17,7 +19,8 @@ android {
 
     buildTypes {
         debug {
-            testCoverageEnabled true
+            enableUnitTestCoverage true
+            enableAndroidTestCoverage true
         }
         release {
             minifyEnabled false

--- a/plugin/src/test/test-fixtures/multi-module/app/src/main/AndroidManifest.xml
+++ b/plugin/src/test/test-fixtures/multi-module/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.neotech.app"
     >
 
     <application>

--- a/plugin/src/test/test-fixtures/multi-module/library_android/build.gradle
+++ b/plugin/src/test/test-fixtures/multi-module/library_android/build.gradle
@@ -5,7 +5,9 @@ plugins {
 
 android {
 
+    namespace "org.neotech.library.a"
     compileSdkVersion libs.versions.androidCompileSdk.get().toInteger()
+
     defaultConfig {
         minSdkVersion libs.versions.androidMinSdk.get().toInteger()
         targetSdkVersion libs.versions.androidTargetSdk.get().toInteger()
@@ -17,6 +19,7 @@ android {
 
     buildTypes {
         debug {
+
             testCoverageEnabled true
         }
         release {

--- a/plugin/src/test/test-fixtures/multi-module/library_android/src/main/AndroidManifest.xml
+++ b/plugin/src/test/test-fixtures/multi-module/library_android/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.neotech.library.a" />
+<manifest />


### PR DESCRIPTION
This changes the plugin to specifically support Android Gradle Plugin 7.3.

This mainly means that the plugin now also checks `enableUnitTestCoverage` and `enableAndroidTestCoverage` as well as the now (in AGP 7.3) deprecated property `testCoverageEnabled`.

