### PR TITLE
Add: Coverage from Gradle Managed Devices.

### DIFF
--- a/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/JaCoCoConfiguration.kt
+++ b/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/JaCoCoConfiguration.kt
@@ -67,6 +67,8 @@ internal fun Project.getExecutionDataFileTree(includeUnitTestResults: Boolean, i
 
         // Android Build Tools Plugin 7.1+
         buildFolderPatterns.add("outputs/code_coverage/*/connected/*/coverage.ec")
+        // Gradle Managed Devices
+        buildFolderPatterns.add("outputs/managed_device_code_coverage/*/coverage.ec")
     }
     return if(buildFolderPatterns.isEmpty()) {
         null

--- a/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePlugin.kt
+++ b/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePlugin.kt
@@ -6,6 +6,7 @@ import com.android.build.api.dsl.BuildType
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.Variant
 import com.android.build.gradle.AppExtension
+import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.api.SourceKind
 import org.gradle.api.GradleException
@@ -176,6 +177,10 @@ class RootCoveragePlugin : Plugin<Project> {
         }
         if (rootProjectExtension.shouldExecuteAndroidTests() && (buildType.enableAndroidTestCoverage || buildType.isTestCoverageEnabled)) {
             dependsOn("$path:connected${name}AndroidTest")
+
+            if (subProject.extensions.getByType(BaseExtension::class.java).testOptions.managedDevices.devices.isNotEmpty()) {
+                dependsOn("$path:allDevices${name}AndroidTest")
+            }
         }
 
         sourceDirectories.from(variant.sources.java?.all)

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
@@ -76,6 +76,9 @@ class IntegrationTest(
     private fun BuildResult.assertAppCoverageReport() {
         assertThat(task(":app:coverageReport")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
+        // Assert that the tests have been run on  Gradle Managed Devices
+        assertThat(task(":app:allDevicesDebugAndroidTest")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
         val report = CoverageReport.from(File(projectRoot, "app/build/reports/jacoco.csv"))
 
         report.assertNotInReport("org.neotech.app", "MustBeExcluded")

--- a/plugin/src/test/test-fixtures/multi-module/app/build.gradle
+++ b/plugin/src/test/test-fixtures/multi-module/app/build.gradle
@@ -37,8 +37,18 @@ android {
         unitTests {
             includeAndroidResources = true
         }
+
+        managedDevices {
+            devices {
+                nexusoneapi30 (com.android.build.api.dsl.ManagedVirtualDevice) {
+                    device = "Nexus One"
+                    apiLevel = 30
+                    systemImageSource = "aosp-atd"
+                }
+            }
+        }
     }
-    
+
     kotlinOptions {
         jvmTarget = "1.8"
     }


### PR DESCRIPTION
[Gradle Managed Devices](https://developer.android.com/studio/test/gradle-managed-devices) collect code coverage (if configured) for instrumented tests as well. The path at which the coverage files are written is `build/outputs/managed_device_code_coverage/<managed device name>/coverage.ec`.

The Android Gradle Plugin creates an ["allDevices" task](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/internal/TaskManager.kt;l=1782-1788;drc=2538ca70995da0faa6988ffdfbebfb15dd1f7742), which has to run if instrumented Android tests are enabled according to the configuration.