### PR TITLE
Add: Support for running instrumented tests on Gradle Managed Devices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,10 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+        uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: '11'
       - name: test
         uses: reactivecircus/android-emulator-runner@v2
@@ -18,6 +19,6 @@ jobs:
           api-level: 28
           script: ./gradlew clean test --stacktrace
       - name: upload coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ./plugin/build/reports/jacoco/test/jacocoTestReport.xml

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ repo/
 build/
 */out/*/classes/*
 plugin/src/test/test-fixtures/multi-module/gradle.properties
+plugin/src/test/test-fixtures/multi-module/build.gradle

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ rootCoverage {
    // Since 1.4: Sets jacoco.includeNoLocationClasses, so you don't have to. Helpful when using Robolectric
    // which usually requires this attribute to be true
    includeNoLocationClasses false
+
+   // Upcoming in 1.7: If set to true instrumented tests will be attempt to run on
+   // Gradle Managed Devices before trying devices connected through other means (ADB).
+   runOnGradleManagedDevices false
+   
+   // Upcoming in 1.7: The name of the Gradle Managed device to run instrumented tests on.
+   // This is only used if `runOnGradleManagedDevices` is set to true. If not given tests will be
+   // run on all available Gradle Managed Devices
+   gradleManagedDeviceName "nexusoneapi30"
 }
 ```
 

--- a/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/JaCoCoConfiguration.kt
+++ b/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/JaCoCoConfiguration.kt
@@ -67,6 +67,8 @@ internal fun Project.getExecutionDataFileTree(includeUnitTestResults: Boolean, i
 
         // Android Build Tools Plugin 7.1+
         buildFolderPatterns.add("outputs/code_coverage/*/connected/*/coverage.ec")
+        // Gradle Managed Devices
+        buildFolderPatterns.add("outputs/managed_device_code_coverage/*/coverage.ec")
     }
     return if(buildFolderPatterns.isEmpty()) {
         null

--- a/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePluginExtension.kt
+++ b/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePluginExtension.kt
@@ -73,6 +73,18 @@ open class RootCoveragePluginExtension {
      */
     var includeUnitTestResults = true
 
+    /**
+     * The name of the Gradle Managed device to run instrumented tests on, if null tests will be attempted to run on any
+     * connected emulator.
+     */
+    var gradleManagedDeviceName: String? = null
+
+    /**
+     * If set to true (default is false) this plugin will attempt to run on Gradle Managed Devices before trying devices
+     * connected through other means (Non Gradle Managed Devices).
+     */
+    var runOnGradleManagedDevices: Boolean = false
+    
     internal fun shouldExecuteAndroidTests() = executeTests && executeAndroidTests && includeAndroidTestResults
 
     internal fun shouldExecuteUnitTests() = executeTests && executeUnitTests && includeUnitTestResults

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/util/ProjectGeneration.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/util/ProjectGeneration.kt
@@ -27,10 +27,19 @@ internal fun Properties.put(properties: Properties) {
 }
 
 internal fun File.getProperties(): Properties = inputStream().use {
-        Properties().apply {
-            load(it)
-        }
+    Properties().apply {
+        load(it)
     }
+}
+
+internal fun Properties.toGroovyString(): String = map {
+    val stringValue = it.value as String
+    if (stringValue.toBooleanStrictOrNull() != null) {
+        "${it.key} ${it.value}"
+    } else {
+        "${it.key} \"${it.value}\""
+    }
+}.joinToString(separator = System.lineSeparator())
 
 /**
  * Tries to resolve the Android SDK directory. This function first tries the ANDROID_HOME system

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/util/SimpleTemplate.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/util/SimpleTemplate.kt
@@ -1,0 +1,31 @@
+package org.neotech.plugin.rootcoverage.util
+
+import java.io.Closeable
+import java.io.InputStream
+import java.nio.charset.Charset
+
+
+/**
+ * Super quick and dirty "template engine" loosely based on mustache style templating.
+ */
+internal class SimpleTemplate {
+
+    private val map = mutableMapOf<String, String>()
+
+    fun putValue(key: String, value: String) {
+        map[key] = value
+    }
+
+    fun process(inputStream: InputStream, charset: Charset): String {
+        val content = inputStream.bufferedReader(charset).readLines()
+        val result = mutableListOf<String>()
+        content.forEach { line ->
+            var adjustedLine = line
+            map.forEach {
+                adjustedLine = line.replace("{{${it.key}}}", it.value)
+            }
+            result.add(adjustedLine)
+        }
+        return result.joinToString(System.lineSeparator())
+    }
+}

--- a/plugin/src/test/test-fixtures/multi-module/app/build.gradle
+++ b/plugin/src/test/test-fixtures/multi-module/app/build.gradle
@@ -37,8 +37,17 @@ android {
         unitTests {
             includeAndroidResources = true
         }
+        managedDevices {
+            devices {
+                nexusoneapi30 (com.android.build.api.dsl.ManagedVirtualDevice) {
+                    device = "Nexus One"
+                    apiLevel = 30
+                    systemImageSource = "aosp-atd"
+                }
+            }
+        }
     }
-    
+
     kotlinOptions {
         jvmTarget = "1.8"
     }

--- a/plugin/src/test/test-fixtures/multi-module/build.gradle.tmp
+++ b/plugin/src/test/test-fixtures/multi-module/build.gradle.tmp
@@ -21,14 +21,8 @@ jacoco {
 }
 
 rootCoverage {
-    generateHtml true
-    generateXml false
-    generateCsv true
-    buildVariant "debug"
-    executeTests true
-    includeUnitTestResults true
-    includeAndroidTestResults true
-    includeNoLocationClasses true
 
     excludes = ["**/MustBeExcluded.class"]
+
+    {{configuration}}
 }

--- a/plugin/src/test/test-fixtures/multi-module/configurations/connected-device.properties
+++ b/plugin/src/test/test-fixtures/multi-module/configurations/connected-device.properties
@@ -1,0 +1,8 @@
+generateHtml=true
+generateXml=false
+generateCsv=true
+buildVariant=debug
+executeTests=true
+includeUnitTestResults=true
+includeAndroidTestResults=true
+includeNoLocationClasses=true

--- a/plugin/src/test/test-fixtures/multi-module/configurations/gradle-managed-device.properties
+++ b/plugin/src/test/test-fixtures/multi-module/configurations/gradle-managed-device.properties
@@ -1,0 +1,11 @@
+generateHtml=true
+generateXml=false
+generateCsv=true
+buildVariant=debug
+executeTests=true
+includeUnitTestResults=true
+includeAndroidTestResults=true
+includeNoLocationClasses=true
+
+runOnGradleManagedDevices=true
+gradleManagedDeviceName=nexusoneapi30

--- a/plugin/src/test/test-fixtures/multi-module/library_android/build.gradle
+++ b/plugin/src/test/test-fixtures/multi-module/library_android/build.gradle
@@ -33,6 +33,18 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    testOptions {
+        managedDevices {
+            devices {
+                nexusoneapi30 (com.android.build.api.dsl.ManagedVirtualDevice) {
+                    device = "Nexus One"
+                    apiLevel = 30
+                    systemImageSource = "aosp-atd"
+                }
+            }
+        }
+    }
+
     kotlinOptions {
         jvmTarget = "1.8"
     }


### PR DESCRIPTION
This PR adds experimental support for running instrumented tests on Gradle Managed Devices.

Some credit has to go to @bddckr for his initial PR on this (see: #73)