### PR TITLE
Add: test to verify if coverage is created with `clearPackageData=true`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ androidGradlePluginApi = { module = "com.android.tools.build:gradle-api",   vers
 junit               = { module = "junit:junit",                                              version = "4.13.2" }
 truth               = { module = "com.google.truth:truth",                                   version = "1.1.3" }
 supportTestRunner   = { module = "androidx.test:runner",                                     version = "1.5.2" }
+testOrchestrator    = { module = "androidx.test:orchestrator",                               version = "1.4.2" }
 espressoCore        = { module = "androidx.test.espresso:espresso-core",                     version = "3.5.1" }
 androidJUnit        = { module = "androidx.test.ext:junit",                                  version = "1.1.5" }
 commonsCsv          = { module = "org.apache.commons:commons-csv",                           version = "1.10.0" }

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/util/SimpleTemplate.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/util/SimpleTemplate.kt
@@ -9,9 +9,9 @@ import java.nio.charset.Charset
  */
 internal class SimpleTemplate {
 
-    private val map = mutableMapOf<String, String>()
+    private val map = mutableMapOf<String, String?>()
 
-    fun putValue(key: String, value: String) {
+    fun putValue(key: String, value: String?) {
         map[key] = value
     }
 
@@ -43,7 +43,7 @@ internal class SimpleTemplate {
                     }
 
                     // Get the replacement string and indent it
-                    val replacement = mapWithBrackets[indexOf.second]!!.prependWhitespaceIndentExceptFirstLine(indent)
+                    val replacement = mapWithBrackets[indexOf.second] ?: "".prependWhitespaceIndentExceptFirstLine(indent)
 
                     adjustedLine.replace(indexOf.first, indexOf.first + indexOf.second.length, replacement)
                     startIndex += replacement.length

--- a/plugin/src/test/test-fixtures/multi-module/app/build.gradle.tmp
+++ b/plugin/src/test/test-fixtures/multi-module/app/build.gradle.tmp
@@ -15,6 +15,10 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        {{defaultConfig.clearPackageData}}
+
+        {{defaultConfig.testOrchestrator}}
     }
 
     buildFeatures {
@@ -42,8 +46,9 @@ android {
             includeAndroidResources = true
         }
 
-        {{managedDevices}}
+        {{testOptions.testOrchestrator}}
 
+        {{managedDevices}}
     }
 
     kotlinOptions {
@@ -57,5 +62,11 @@ dependencies {
     implementation libs.appCompat
 
     testImplementation libs.bundles.androidTest
+
+    {{dependencies.testOrchestrator}}
+
+    androidTestUtil "androidx.test.services:test-services:1.4.2"
+
     androidTestImplementation libs.bundles.androidInstrumentedTest
+
 }

--- a/plugin/src/test/test-fixtures/multi-module/configurations/connected-device-clear-package-data.yaml
+++ b/plugin/src/test/test-fixtures/multi-module/configurations/connected-device-clear-package-data.yaml
@@ -1,0 +1,38 @@
+# This test was added in reaction to:
+# https://github.com/NeoTech-Software/Android-Root-Coverage-Plugin/issues/83
+#
+# Currently this test case fails, but probably not because of this plugin as it seems to be
+# an Android tooling issue:
+# - https://issuetracker.google.com/issues/126258801
+# - https://issuetracker.google.com/issues/123987001
+#
+# For now this test configuration is ignored (until Google fixes this)
+ignore: true
+projectConfiguration:
+  addGradleManagedDevice: false
+  clearPackageData: true
+  testOrchestrator: true
+pluginConfiguration:
+  properties:
+    - name: generateHtml
+      value: true
+    - name: generateXml
+      value: false
+    - name: generateCsv
+      value: true
+
+    - name: buildVariant
+      value: debug
+
+    - name: executeUnitTests
+      value: true
+    - name: includeUnitTestResults
+      value: true
+
+    - name: executeAndroidTests
+      value: false
+    - name: includeAndroidTestResults
+      value: true
+
+    - name: includeNoLocationClasses
+      value: true


### PR DESCRIPTION
Turns out this test does not succeed, but this seems to be a bug in the Android Tooling and not something this plugin can solve right now.

See: #83