### PR TITLE
Fix: rootCoverageReport ignores androidTests coverage results when executeAndroidTests is false

### DIFF
--- a/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePlugin.kt
+++ b/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePlugin.kt
@@ -53,7 +53,7 @@ class RootCoveragePlugin : Plugin<Project> {
     }
 
 
-    private fun createSubProjectCoverageTask(subProject: Project): Task {
+    private fun createSubProjectCoverageTask(subProject: Project) {
         val task = subProject.createJacocoReportTask(
             taskName = "coverageReport",
             taskGroup = "reporting",
@@ -62,7 +62,6 @@ class RootCoveragePlugin : Plugin<Project> {
         )
         // subProject.assertAndroidCodeCoverageVariantExists()
         task.addSubProject(task.project)
-        return task
     }
 
     private fun createCoverageTaskForRoot(project: Project) {
@@ -84,8 +83,7 @@ class RootCoveragePlugin : Plugin<Project> {
             }
             rootCoverageTask.addSubProject(it)
 
-            val subProjectCoverageTask = createSubProjectCoverageTask(it)
-            rootCoverageTask.dependsOn(subProjectCoverageTask)
+            createSubProjectCoverageTask(it)
         }
 
         project.tasks.create("rootCodeCoverageReport").apply {
@@ -161,12 +159,7 @@ class RootCoveragePlugin : Plugin<Project> {
             //
             // In theory we don't need to do this if `rootProjectExtension.includeAndroidTestResults` is false, so we could check that, but
             // it also does not hurt.
-            subProject.tasks.configureEach { task ->
-                if (task.path == androidTestTask.taskPath) {
-                    dependsOn(task.path)
-                }
-            }
-            mustRunAfter("$path:connected${variantName}AndroidTest")
+            mustRunAfter(androidTestTask.taskPath)
         }
 
         sourceDirectories.from(variant.sources.java?.all)

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/IntegrationTest.kt
@@ -89,7 +89,12 @@ class IntegrationTest(
         // Note: rootCodeCoverageReport is the old and deprecated name of the rootCoverageReport task, it is
         // used to check whether the old name properly aliases to the new task name.
         val gradleCommands = if (configuration.pluginConfiguration.getPropertyValue("executeAndroidTests") == "false") {
-            listOf("clean", "connectedDebugAndroidTest", "coverageReport", "rootCodeCoverageReport", "--stacktrace")
+            val runOnGradleManagedDevices = configuration.pluginConfiguration.getPropertyValue("runOnGradleManagedDevices") ?: "false"
+            if (runOnGradleManagedDevices == "false") {
+                listOf("clean", "connectedDebugAndroidTest", "coverageReport", "rootCodeCoverageReport", "--stacktrace")
+            } else {
+                listOf("clean", "nexusoneapi30DebugAndroidTest", "coverageReport", "rootCodeCoverageReport", "--stacktrace")
+            }
         } else {
             listOf("clean", "coverageReport", "rootCodeCoverageReport", "--stacktrace")
         }

--- a/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/util/GradleBuildExtensions.kt
+++ b/plugin/src/test/kotlin/org/neotech/plugin/rootcoverage/util/GradleBuildExtensions.kt
@@ -11,3 +11,7 @@ fun BuildResult.assertSuccessful() {
 fun BuildResult.assertTaskSuccess(taskPath: String) {
     assertThat(task(taskPath)!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 }
+
+fun BuildResult.assertTaskNotExecuted(taskPath: String) {
+    assertThat(task(taskPath)).isNull()
+}

--- a/plugin/src/test/test-fixtures/multi-module/configurations/gradle-managed-device-dont-execute-android-tests.yaml
+++ b/plugin/src/test/test-fixtures/multi-module/configurations/gradle-managed-device-dont-execute-android-tests.yaml
@@ -1,0 +1,30 @@
+projectConfiguration:
+  addGradleManagedDevice: true
+pluginConfiguration:
+  properties:
+    - name: generateHtml
+      value: true
+    - name: generateXml
+      value: false
+    - name: generateCsv
+      value: true
+
+    - name: buildVariant
+      value: debug
+
+    - name: executeUnitTests
+      value: true
+    - name: executeAndroidTests
+      value: false
+
+    - name: includeUnitTestResults
+      value: true
+    - name: includeAndroidTestResults
+      value: true
+    - name: includeNoLocationClasses
+      value: true
+
+    - name: runOnGradleManagedDevices
+      value: true
+    - name: gradleManagedDeviceName
+      value: nexusoneapi30


### PR DESCRIPTION
# Problem 
In our project we are using gradle managed devices to execute ui tests. Ui tests launch configuration is a bit complicated in our use case, so I had to launch ui tests separately from `Android-Root-Coverage-Plugin`. And then after ui tests have finished it's execution, I am using `:rootCoverageReport"` The problem here, is that coverage results from ui tests are being ignored by `:rootCoverageReport`. This happens only with gradle managed devices, if I manually execute ui tests on connected emulator, and than use `:rootCoverageReport` to create aggregated coverage report, everything works as expected.

I have created new configuration `gradle-managed-device-dont-execute-android-tests.yaml` for `IntegrationTest.kt`, that reproduces the issue above.

# Solution

This pull request also contains fix of that problem. Here are key components of the fix:

1. It turned out that  subProject.getExecutionDataFileTree always received `includeGradleManagedDevicesResults = false`, in case of `executeAndroidTests` is false. Now that is fixed.
2. I had to switch from `project.tasks.findByPath("$path:allDevices${name}AndroidTest")` to `subProject.tasks.configureEach` inside `JacocoReport.addSubProjectVariant`. `project.tasks.findByPath` was always returing null, because task`$path:allDevices${name}AndroidTest` wasn't configured yet at the time `project.tasks.findByPath` is called.
3. The fix introduces explicit dependency between  ":rootCoverageReport" and "coverageReport" tasks of subprojects. Without this change, gradle build sometimes was failing with error like 
```text
Error: gradle Task : "rootCoverageReport" uses the output of task ':nexusoneapi30DebugAndroidTest" without declaring an explicit or implicit dependency.
```