### PR TITLE
Release 1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ following methods:
   ```groovy
   // Below buildscript {}
   plugins {
-      id "nl.neotech.plugin.rootcoverage" version "1.8.0"
+      id "nl.neotech.plugin.rootcoverage" version "1.9.0"
   }
   ```
 </details>
@@ -42,7 +42,7 @@ following methods:
    
    buildscript {
       dependencies {
-         classpath 'nl.neotech.plugin:android-root-coverage-plugin:1.8.0'
+         classpath 'nl.neotech.plugin:android-root-coverage-plugin:1.9.0'
       }
    }
    ```
@@ -137,26 +137,21 @@ rootCoverage {
 
 
 # 4. Compatibility
-| Version    | [Android Gradle plugin version](https://developer.android.com/studio/releases/gradle-plugin#updating-gradle) | Gradle version    |
-|------------|--------------------------------------------------------------------------------------------------------------|-------------------|
-| **1.8.0**  | 8.3.0-alpha05 - 8.3.2                                                                                        | 8.4+ *(note 1)*   |
-| **Note 2** | 8.0 - 8.3.0-alpha04                                                                                          | n.a.              |
-| **1.7.1**  | 7.4                                                                                                          | 7.5+              |
-| **1.6.0**  | 7.3                                                                                                          | 7.4+              |
-| **1.5.3**  | 7.2                                                                                                          | 7.3+              |
-| **Note 3** | 7.0 - 7.2.0-alpha05                                                                                          | n.a.              |
-| **1.4.0**  | 4.2<br/>4.1                                                                                                  | 6.7.1+<br/>6.5+   |
-| **1.3.1**  | 4.0<br/>3.6                                                                                                  | 6.1.1+<br/>5.6.4+ |
-| **1.2.1**  | 3.5                                                                                                          | 5.4.1+            |
-| **1.1.2**  | 3.4                                                                                                          | 5.1.1+            |
-| **1.1.1**  | 3.3                                                                                                          | 4.10.1+           |
-| **1.0.2**  | 3.2                                                                                                          | 4.6+              |
-
-<details open>
-  <summary><b>Note 1: AGP 8.3.0 and Gradle 8.3</b></summary>
-  
-  *The Android developers website claims AGP 8.3 requires Gradle version 8.3 as a minimum, however from at least alpha release 11 this seems to instead be Gradle version 8.4!*
-</details>
+| Version    | [Android Gradle plugin version](https://developer.android.com/studio/releases/gradle-plugin#updating-gradle) | Gradle version         |
+|------------|--------------------------------------------------------------------------------------------------------------|------------------------|
+| **1.9.0**  | 8.6.0                                                                                                        | 8.7+                   |
+| **1.8.0**  | 8.5.2<br/>8.4.2<br/>8.3.0-alpha05 - 8.3.2                                                                    | 8.6+<br/>8.5+<br/>8.4+ |
+| **Note 2** | 8.0 - 8.3.0-alpha04                                                                                          | n.a.                   |
+| **1.7.1**  | 7.4                                                                                                          | 7.5+                   |
+| **1.6.0**  | 7.3                                                                                                          | 7.4+                   |
+| **1.5.3**  | 7.2                                                                                                          | 7.3+                   |
+| **Note 3** | 7.0 - 7.2.0-alpha05                                                                                          | n.a.                   |
+| **1.4.0**  | 4.2<br/>4.1                                                                                                  | 6.7.1+<br/>6.5+        |
+| **1.3.1**  | 4.0<br/>3.6                                                                                                  | 6.1.1+<br/>5.6.4+      |
+| **1.2.1**  | 3.5                                                                                                          | 5.4.1+                 |
+| **1.1.2**  | 3.4                                                                                                          | 5.1.1+                 |
+| **1.1.1**  | 3.3                                                                                                          | 4.10.1+                |
+| **1.0.2**  | 3.2                                                                                                          | 4.6+                   |
 
 <details open>
   <summary><b>Note 2: AGP 8.0-8.3.0-alpha04</b></summary>

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,4 +1,4 @@
 POM_ARTIFACT_ID=android-root-coverage-plugin
-VERSION_NAME=1.8.0
+VERSION_NAME=1.9.0
 POM_NAME=Android Root Coverage Plugin
 POM_DESCRIPTION=A Gradle plugin for easy generation of combined code coverage reports for Android projects with multiple modules.


### PR DESCRIPTION
- Fixed: Code coverage data not picked up when using Gradle Managed Devices in combination with flavors (#102)
- Fixed: Code coverage data not picked up when using Gradle Managed Devices in combination with executeAndroidTests=false (thanks to @k4k7us23)  (#104)
- Based on Android Gradle Plugin 8.6 API
- Compatible with Gradle version 8.7+