### PR TITLE
Add: Extension function on 'Project' to easily configure the 'rootCoverage' extension

### DIFF
--- a/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePluginExtension.kt
+++ b/plugin/src/main/kotlin/org/neotech/plugin/rootcoverage/RootCoveragePluginExtension.kt
@@ -1,5 +1,11 @@
 package org.neotech.plugin.rootcoverage
 
+import org.gradle.api.Project
+
+fun Project.rootCoverage(configure: RootCoveragePluginExtension.() -> Unit) {
+    extensions.configure(RootCoveragePluginExtension::class.java, configure)
+}
+
 open class RootCoveragePluginExtension {
 
     var generateCsv: Boolean = false


### PR DESCRIPTION
This is especially helpful when using Kotlin (.kts) as language for build files.

Closes: #112